### PR TITLE
Fix config for replacing `http://rubygems.org`

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -39,7 +39,8 @@ https://gems.ruby-china.org
     <p>你可以用 Bundler 的 <a href="http://bundler.io/v1.5/bundle_config.html#gem-source-mirrors">Gem 源代码镜像命令</a>。</p>
 
 <div class="highlight">
-<pre><code><span class="nv">$ </span>bundle config mirror.https://rubygems.org https://gems.ruby-china.org</code></pre>
+<pre><code><span class="nv">$ </span>bundle config mirror.http://rubygems.org https://gems.ruby-china.org
+<span class="nv">$ </span>bundle config mirror.https://rubygems.org https://gems.ruby-china.org</code></pre>
 </div>
 
     <p>这样你不用改你的 Gemfile 的 source。</p>


### PR DESCRIPTION
mirror 配置增加了一行：

`bundle config mirror.http://rubygems.org https://gems.ruby-china.org`

某些 `Gemfile` 中写的 source 是 `http://rubygems.org`，`http` 开头